### PR TITLE
Fix minor QA issues

### DIFF
--- a/data/cpu-x-root.desktop.in
+++ b/data/cpu-x-root.desktop.in
@@ -1,12 +1,11 @@
 [Desktop Entry]
 Name=CPU-X (Root)
-Encoding=UTF-8
 Comment=Gathers information on CPU, motherboard and more
 Comment[fr]=Récolte des informations sur le CPU, la carte-mère et plus
 Comment[pt_BR]=Coleta informações sobre sua CPU, placa-mãe and mais
 Exec=@EXEC@
 TryExec=@TRYEXEC@
-Icon=cpu-x.png
+Icon=cpu-x
 Type=Application
 Categories=GTK;System;
 Terminal=false

--- a/data/cpu-x.desktop.in
+++ b/data/cpu-x.desktop.in
@@ -1,11 +1,10 @@
 [Desktop Entry]
 Name=CPU-X
-Encoding=UTF-8
 Comment=Gathers information on CPU, motherboard and more
 Comment[fr]=Récolte des informations sur le CPU, la carte-mère et plus
 Comment[pt_BR]=Coleta informações sobre sua CPU, placa-mãe and mais
 Exec=@EXEC@
-Icon=cpu-x.png
+Icon=cpu-x
 Type=Application
 Categories=GTK;System;
 Terminal=false


### PR DESCRIPTION
This commit fix two QA issues:
1. The "Encoding" is deprecated. The line should be deleted.
2. The icon is an icon name with an extension, but there should be
no extension as described in the Icon Theme Specification if the
value is not an absolute path. This will be fatal in the future.