### PR TITLE
Add CPU Technology for Intel Core 2 Processors

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -182,8 +182,9 @@ static int cpu_technology(Labels *data)
 				if(data->cpu_ext_model == 69) return 22; // Haswell
 			case 6:
 				if(data->cpu_ext_model == 6) return 65;  // P4 Cedar Mill / PD Presler
+				if(data->cpu_ext_model == 22) return 65; // C2 Conroe-L
 			case 7:
-				if(data->cpu_ext_model == 23) return 45;
+				if(data->cpu_ext_model == 23) return 45; // C2 Wolfdale / Yorkfield / Penryn
 				if(data->cpu_ext_model == 71) return 14; // Broadwell
 			case 10:
 				if(data->cpu_ext_model == 26 || data->cpu_ext_model == 30) return 45; // Nehalem
@@ -199,6 +200,7 @@ static int cpu_technology(Labels *data)
 				if(data->cpu_ext_model == 62) return 22; // Ivy Bridge-E
 				if(data->cpu_ext_model == 94) return 14; // Skylake
 			case 15:
+				if(data->cpu_ext_model == 15) return 65; // C2 Conroe / Allendale / Kentsfield / Merom
 				if(data->cpu_ext_model == 63) return 22; // Haswell-E
 		}
 	}


### PR DESCRIPTION
45nm = C2 Wolfdale / Yorkfield / Penryn
65nm = C2 Conroe / Allendale / Kentsfield / Merom / Conroe-L

https://en.wikipedia.org/wiki/Core_2#Models

These 26 cpu-z screenshots I found provide all the needed evidence...
http://s000.tinyupload.com/index.php?file_id=00303685418662206003
