### PR TITLE
Add GNU-stack on routines*.asm

### DIFF
--- a/src/bandwidth/routines32.asm
+++ b/src/bandwidth/routines32.asm
@@ -19,6 +19,10 @@
 ;  The author may be reached at veritas@comcast.net.
 ;=============================================================================
 
+%ifidn __OUTPUT_FORMAT__,elf32
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 bits	32
 cpu	ia64
 

--- a/src/bandwidth/routines64.asm
+++ b/src/bandwidth/routines64.asm
@@ -19,6 +19,10 @@
 ;  The author may be reached at veritas@comcast.net.
 ;=============================================================================
 
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 bits	64
 cpu	ia64
 


### PR DESCRIPTION
If an assembler source contains no GNU-stack note, the system
by default assumes that an executable stack may be required.

```
# scanelf -qeR .
RWX --- ---  ./work/cpu-x-9999_build/output/bin/cpu-x
!WX --- ---  ./work/cpu-x-9999_build/src/bandwidth/routines64.o

# readelf -S ./work/cpu-x-9999_build/src/bandwidth/routines64.o
There are 5 section headers, starting at offset 0x40:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000000000  00000000
       0000000000000000  0000000000000000           0     0     0
  [ 1] .text             PROGBITS         0000000000000000  00000180
       0000000000002439  0000000000000000  AX       0     0     64
  [ 2] .shstrtab         STRTAB           0000000000000000  000025c0
       0000000000000021  0000000000000000           0     0     1
  [ 3] .symtab           SYMTAB           0000000000000000  000025f0
       0000000000000ff0  0000000000000018           4    70     8
  [ 4] .strtab           STRTAB           0000000000000000  000035e0
       0000000000000bcc  0000000000000000           0     0     1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), l (large)
  I (info), L (link order), G (group), T (TLS), E (exclude), x (unknown)
  O (extra OS processing required) o (OS specific), p (processor specific)
```