### PR TITLE
Added AM4 Codenames & Trying to resolve an issue where wrong nvidia driver is chosen.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -662,7 +662,9 @@ static int find_driver(struct pci_dev *dev, char *driver_name, Labels *data)
 	casprintf(&data->g_data->device_path[data->gpu_count], false, "%s/devices/%04x:%02x:%02x.%d",
 		base, dev->domain, dev->bus, dev->dev, dev->func);
 
-	if(popen_to_str(&buff, "modinfo --field name %s", dev->module_alias))
+	/* remove the trailing newline on module_alias */
+	dev->module_alias[strcspn(dev->module_alias, "\n")] = 0;
+	if(popen_to_str(&buff, "modinfo --field name %s | xargs -d '\n'", dev->module_alias))
 		GOTO_ERROR("modinfo");
 
 	snprintf(driver_name, MAXSTR, _("(%s driver)"), buff);

--- a/src/databases.h
+++ b/src/databases.h
@@ -160,6 +160,9 @@ const Package_DB package_amd[] =
 	{ "Turion X2",                      "TK",            "S1g1 (PGA-ZIF)" },
 	{ "Zambezi",                        NULL,            "AM3+ (PGA-ZIF)" },
 	{ "Vishera",                        NULL,            "AM3+ (PGA-ZIF)" },
+	{ "Summit Ridge",                   NULL,            "AM4 (PGA-ZIF)"  },
+	{ "Raven Ridge",                    NULL,            "AM4 (PGA-ZIF)"  },
+	{ "Pinnacle Ridge",                 NULL,            "AM4 (PGA-ZIF)"  },
 	{ NULL,                             NULL,            NULL             }
 	//Codename                          Model            Socket
 };


### PR DESCRIPTION
Few notes.
I added the Code Names for Summit Ridge, Raven Ridge and Pinnacle Ridge. I only tested Summit Ridge:
![image](https://user-images.githubusercontent.com/6548135/59969183-0eb3e300-9516-11e9-9de4-d8821a6e7751.png)

There seems to be a regression with in which nvidia driver is chosen. modinfo reports nouveau first, even when nouveau isn't installed or loaded. This causes CPU-X to not be able to grab sensor information from nvidia-settings:
```~/git/CPU-X master*
❯ modinfo --field name pci:v000010DEd00001F07sv00001462sd00003730bc03sc00i00
nouveau
nvidia_drm
nvidia
```

My change tries to fix this change, but I'm not a big fan of what I am doing (It also requires you to remove the newline at the end of module_alias) The below changes have a side effect of printing all 3 nvidia drivers (nouvea, nvidia_drm and nvidia) in the vendor field of the graphics tab:
![image](https://user-images.githubusercontent.com/6548135/59969205-7cf8a580-9516-11e9-85ca-aa210287d5d8.png)

Not related to my code changes, but there also seem to be some other regressions. I do not see my memory tab in the current git, nor do I see multiplier and bus speed on the CPU tab. Whatever version solus bundles happens to have this information. I can probably work both of these issues as well if they are not currently being worked.