### PR TITLE
Spelling fix: in English language, there plural form and singular for…

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -281,11 +281,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr ""
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr ""
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr ""
 
 #: core.c:1344
@@ -325,7 +325,7 @@ msgid "Root privileges are required to work properly"
 msgstr "تحتاج امتيازات الجذر للعمل كما ينبغي"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "قد لا تستطيع جلب بعض المعلومات"
 
 #: gui_gtk.c:103
@@ -809,7 +809,7 @@ msgid "Disable colored output"
 msgstr "عطِّل الخرج الملون"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "اطبع البيانات لنسخها في قضية"
 
 #: main.c:559

--- a/po/cpu-x.pot
+++ b/po/cpu-x.pot
@@ -274,11 +274,11 @@ msgid   "Calculating CPU multipliers in fallback mode"
 msgstr  ""
 
 #: core.c:1272
-msgid   "Retrieving motherboard informations in fallback mode"
+msgid   "Retrieving motherboard information in fallback mode"
 msgstr  ""
 
 #: core.c:1279
-msgid   "failed to retrieve motherboard informations (fallback mode)"
+msgid   "failed to retrieve motherboard information (fallback mode)"
 msgstr  ""
 
 #: core.c:1344
@@ -318,7 +318,7 @@ msgid   "Root privileges are required to work properly"
 msgstr  ""
 
 #: gui_gtk.c:101 main.c:941
-msgid   "Some informations will not be retrievable"
+msgid   "Some information will not be retrievable"
 msgstr  ""
 
 #: gui_gtk.c:103
@@ -797,7 +797,7 @@ msgid   "Disable colored output"
 msgstr  ""
 
 #: main.c:558
-msgid   "Print required informations to paste in an issue"
+msgid   "Print required information to paste in an issue"
 msgstr  ""
 
 #: main.c:559

--- a/po/cs_CZ.po
+++ b/po/cs_CZ.po
@@ -278,11 +278,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "Násobiče frekvence procesoru zjišťovány v náhradním režimu"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Informace o základní desce zjišťovány v náhradním režimu"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "nepodařilo se získat informace o základní desce (náhradní režim)"
 
 #: core.c:1344
@@ -322,7 +322,7 @@ msgid "Root privileges are required to work properly"
 msgstr "Pro správné fungování je třeba oprávnění správce systému"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Některé informace nebude možné získat"
 
 #: gui_gtk.c:103
@@ -804,7 +804,7 @@ msgid "Disable colored output"
 msgstr "Vypnout obarvování výstupu"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "Vypsat potřebné informace pro přiložení k hlášení problému"
 
 #: main.c:559

--- a/po/de.po
+++ b/po/de.po
@@ -282,11 +282,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "CPU-Multiplikatoren werden in alternativem Modus ermittelt"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Motherboard-Informationen werden in alternativem Modus abgerufen"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "Fehler beim Abrufen der Motherboard-Informationen (alternativer Modus)"
 
 #: core.c:1344
@@ -326,7 +326,7 @@ msgid "Root privileges are required to work properly"
 msgstr "Root-Rechte werden benötigt, um richtig zu funktionieren"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Einige Informationen werden nicht abrufbar sein"
 
 #: gui_gtk.c:103
@@ -811,7 +811,7 @@ msgid "Disable colored output"
 msgstr "Farbige Ausgabe deaktivieren"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "Benötigte Informationen zum Einfügen in einen Problembericht ausgeben"
 
 #: main.c:559

--- a/po/el.po
+++ b/po/el.po
@@ -276,11 +276,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr ""
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr ""
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr ""
 
 #: core.c:1344
@@ -320,7 +320,7 @@ msgid "Root privileges are required to work properly"
 msgstr ""
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr ""
 
 #: gui_gtk.c:103
@@ -799,7 +799,7 @@ msgid "Disable colored output"
 msgstr ""
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr ""
 
 #: main.c:559

--- a/po/fr.po
+++ b/po/fr.po
@@ -281,11 +281,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "Calcule les multiplicateurs du processeur en mode de secours"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Récupère les informations de la carte-mère en mode de secours"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "échec lors de la récupération des informations de la carte-mère (mode de secours)"
 
 #: core.c:1344
@@ -325,7 +325,7 @@ msgid "Root privileges are required to work properly"
 msgstr "Les privilèges du super-utilisateur sont requis pour fonctionner correctement"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Quelques données ne seront pas récupérables"
 
 #: gui_gtk.c:103
@@ -807,7 +807,7 @@ msgid "Disable colored output"
 msgstr "Désactive la sortie colorée"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "Affiche les informations nécessaires à coller dans un rapport de problèmes"
 
 #: main.c:559

--- a/po/id.po
+++ b/po/id.po
@@ -279,11 +279,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr ""
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr ""
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr ""
 
 #: core.c:1344
@@ -323,7 +323,7 @@ msgid "Root privileges are required to work properly"
 msgstr ""
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr ""
 
 #: gui_gtk.c:103
@@ -805,7 +805,7 @@ msgid "Disable colored output"
 msgstr ""
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr ""
 
 #: main.c:559

--- a/po/ko.po
+++ b/po/ko.po
@@ -276,11 +276,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr ""
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr ""
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr ""
 
 #: core.c:1344
@@ -320,7 +320,7 @@ msgid "Root privileges are required to work properly"
 msgstr ""
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr ""
 
 #: gui_gtk.c:103
@@ -799,7 +799,7 @@ msgid "Disable colored output"
 msgstr ""
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr ""
 
 #: main.c:559

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -284,12 +284,12 @@ msgstr "Regner ut CPU-multiplikatorer i tilbakefallsmodus"
 
 #: core.c:1272
 #, fuzzy
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Henter hovedkortinformasjon i tilbakefallsmodus"
 
 #: core.c:1279
 #, fuzzy
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "Klarte ikke å hente hovedkortinformasjon (tilbakefallsmodus)"
 
 #: core.c:1344
@@ -334,7 +334,7 @@ msgid "Root privileges are required to work properly"
 msgstr "Superbrukerprivilegier kreves for at ting skal virke"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Noe info kunne ikke innhentes"
 
 #: gui_gtk.c:103
@@ -833,7 +833,7 @@ msgid "Disable colored output"
 msgstr "Skru av fargelagt utdata"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "Skriv ut påkrevd informasjon å lime inn i en feilrapport"
 
 #: main.c:559

--- a/po/pl.po
+++ b/po/pl.po
@@ -284,11 +284,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "Obliczanie mnożnika CPU w trybie awaryjnym"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Pozyskiwanie informacji o płycie głównej w trybie awaryjnym"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "nie udało się pobrać informacji o płycie głównej (tryb awaryjny)"
 
 #: core.c:1344
@@ -328,7 +328,7 @@ msgid "Root privileges are required to work properly"
 msgstr "Do prawidłowego działania wymagane są prawa użytkownika root"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Niektóre informacje nie mogą być pozyskane"
 
 #: gui_gtk.c:103
@@ -810,7 +810,7 @@ msgid "Disable colored output"
 msgstr ""
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr ""
 
 #: main.c:559

--- a/po/pt.po
+++ b/po/pt.po
@@ -285,11 +285,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "Calculando multiplicadores da CPU em modo fallback"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Recuperando informações da placa-mãe em modo fallback"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "falhou ao recuperar informações da placa-mãe (modo fallback)"
 
 #: core.c:1344
@@ -329,7 +329,7 @@ msgid "Root privileges are required to work properly"
 msgstr "É necessário privilégios de root para funcionar corretamente"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Algumas informações não serão recuperáveis"
 
 #: gui_gtk.c:103
@@ -817,7 +817,7 @@ msgid "Disable colored output"
 msgstr "Desativar saída a cores"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "Imprimir informações necessárias para colar em uma questão"
 
 #: main.c:559

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -280,11 +280,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "Calculando multiplicadores da CPU em modo fallback"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Recuperando informações da placa-mãe em modo fallback"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "falhou ao recuperar informações da placa-mãe (modo fallback)"
 
 #: core.c:1344
@@ -324,7 +324,7 @@ msgid "Root privileges are required to work properly"
 msgstr "É necessário privilégios de root para funcionar corretamente"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Algumas informações não serão recuperáveis"
 
 #: gui_gtk.c:103
@@ -806,7 +806,7 @@ msgid "Disable colored output"
 msgstr "Desabilita a saída colorida"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "Imprimir informações necessárias para colar em uma questão"
 
 #: main.c:559

--- a/po/ru.po
+++ b/po/ru.po
@@ -278,11 +278,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "Подсчет множителей ЦП в fallback-режиме"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "Получение информации о материнской плате в fallback-режиме"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "не удалось получить информацию о материнской плате (fallback-режим)"
 
 #: core.c:1344
@@ -322,7 +322,7 @@ msgid "Root privileges are required to work properly"
 msgstr "Для корректной работы требуются права администратора"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "Невозможно получить некоторые данные"
 
 #: gui_gtk.c:103
@@ -804,7 +804,7 @@ msgid "Disable colored output"
 msgstr "Отключить цветной вывод"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "Вывести требуемую информацию для вставки в отчет об ошибке"
 
 #: main.c:559

--- a/po/tr.po
+++ b/po/tr.po
@@ -279,11 +279,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr ""
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr ""
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr ""
 
 #: core.c:1344
@@ -323,7 +323,7 @@ msgid "Root privileges are required to work properly"
 msgstr ""
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr ""
 
 #: gui_gtk.c:103
@@ -802,7 +802,7 @@ msgid "Disable colored output"
 msgstr ""
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr ""
 
 #: main.c:559

--- a/po/zh.po
+++ b/po/zh.po
@@ -280,11 +280,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr "正在应急模式下计算 CPU 倍频"
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr "正在应急模式下检索主板信息"
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr "无法检索主板信息 (应急模式)"
 
 #: core.c:1344
@@ -324,7 +324,7 @@ msgid "Root privileges are required to work properly"
 msgstr "需要 root 权限以正常工作"
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr "某些信息无法检索"
 
 #: gui_gtk.c:103
@@ -806,7 +806,7 @@ msgid "Disable colored output"
 msgstr "禁用彩色输出"
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr "输出粘贴在问题反馈中的所需信息"
 
 #: main.c:559

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -278,11 +278,11 @@ msgid "Calculating CPU multipliers in fallback mode"
 msgstr ""
 
 #: core.c:1272
-msgid "Retrieving motherboard informations in fallback mode"
+msgid "Retrieving motherboard information in fallback mode"
 msgstr ""
 
 #: core.c:1279
-msgid "failed to retrieve motherboard informations (fallback mode)"
+msgid "failed to retrieve motherboard information (fallback mode)"
 msgstr ""
 
 #: core.c:1344
@@ -322,7 +322,7 @@ msgid "Root privileges are required to work properly"
 msgstr ""
 
 #: gui_gtk.c:101 main.c:941
-msgid "Some informations will not be retrievable"
+msgid "Some information will not be retrievable"
 msgstr ""
 
 #: gui_gtk.c:103
@@ -801,7 +801,7 @@ msgid "Disable colored output"
 msgstr ""
 
 #: main.c:558
-msgid "Print required informations to paste in an issue"
+msgid "Print required information to paste in an issue"
 msgstr ""
 
 #: main.c:559

--- a/src/bandwidth/main.c
+++ b/src/bandwidth/main.c
@@ -2177,7 +2177,7 @@ bandwidth_main (int argc, char **argv)
 
 	printf ("This is bandwidth version %s.\n", RELEASE);
 	printf ("Copyright (C) 2005-2017 by Zack T Smith.\n\n");
-	printf ("This software is covered by the GNU Public License.\n");
+	printf ("This software is covered by the GNU General Public License.\n");
 	printf ("It is provided AS-IS, use at your own risk.\n");
 	printf ("See the file COPYING for more information.\n\n");
 	fflush (stdout);

--- a/src/core.c
+++ b/src/core.c
@@ -1299,14 +1299,14 @@ static int motherboardtab_fallback(Labels *data)
 	int i;
 	const char *id[] = { "board_vendor", "board_name", "board_version", "bios_vendor", "bios_version", "bios_date", NULL };
 
-	MSG_VERBOSE(_("Retrieving motherboard informations in fallback mode"));
+	MSG_VERBOSE(_("Retrieving motherboard information in fallback mode"));
 	/* Tab Motherboard */
 	for(i = 0; id[i] != NULL; i++)
 		err += fopen_to_str(&data->tab_motherboard[VALUE][i], "%s/%s", SYS_DMI, id[i]);
 
 #endif /* __linux__ */
 	if(err)
-		MSG_ERROR(_("failed to retrieve motherboard informations (fallback mode)"));
+		MSG_ERROR(_("failed to retrieve motherboard information (fallback mode)"));
 
 	return err;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -511,7 +511,7 @@ static const struct
 	{ true,            'h', "help",      no_argument,       N_("Print help and exit")                                      },
 	{ true,            'V', "version",   no_argument,       N_("Print version and exit")                                   },
 	{ true,              0, "nocolor",   no_argument,       N_("Disable colored output")                                   },
-	{ true,              0, "issue-fmt", no_argument,       N_("Print required informations to paste in an issue")         },
+	{ true,              0, "issue-fmt", no_argument,       N_("Print required information to paste in an issue")         },
 	{ true,              0, NULL,        0,                 NULL                                                           }
 };
 


### PR DESCRIPTION
…m of information are identical, no trailing 's' for the plural form.

This was discovered by the Debian lintian tool while I packaged your software for Debian (waiting for acceptance by the package archive (ftp)masters).