### PR TITLE
data/cpu-x.desktop.in: Add Keywords= key to .desktop file.

### DIFF
--- a/data/cpu-x.desktop.in
+++ b/data/cpu-x.desktop.in
@@ -11,3 +11,4 @@ Icon=@APP_EXEC@
 Type=Application
 Categories=GTK;System;
 Terminal=false
+Keywords=CPU;system;core;speed;clock;rate;Intel;AMD;motherboard;


### PR DESCRIPTION
Discovered by the Debian lintian tool. These days, all applications should come with a desktop file that ships keywords under which the application should pop up in desktop application search tools. 