### PR TITLE
Core: reword nonsensical CPU/socket warning message

### DIFF
--- a/po/cpu-x.pot
+++ b/po/cpu-x.pot
@@ -22,7 +22,7 @@ msgstr  ""
 
 #: core.c:229
 #, c-format
-msgid   "Your CPU does not belong in database ==> %s, model: %i, ext. model: "
+msgid   "Your CPU is not present in the database ==> %s, model: %i, ext. model: "
         "%i, ext. family: %i"
 msgstr  ""
 
@@ -218,7 +218,7 @@ msgstr  ""
 
 #: core.c:1288
 #, c-format
-msgid   "Your CPU socket does not belong in database ==> %s, codename: %s"
+msgid   "Your CPU socket is not present in the database ==> %s, codename: %s"
 msgstr  ""
 
 #: core.c:1307
@@ -702,7 +702,7 @@ msgid   "Read CPUID raw data from a given file"
 msgstr  ""
 
 #: main.c:347
-msgid   "Only print a message if CPU does not belong in database"
+msgid   "Only print a message if CPU is not present in the database"
 msgstr  ""
 
 #: main.c:358

--- a/src/core.c
+++ b/src/core.c
@@ -226,7 +226,7 @@ static int cpu_technology(Labels *data)
 		}
 	}
 
-	MSG_WARNING(_("Your CPU does not belong in database ==> %s, model: %i, ext. model: %i, ext. family: %i"),
+	MSG_WARNING(_("Your CPU is not present in the database ==> %s, model: %i, ext. model: %i, ext. family: %i"),
 	            data->tab_cpu[VALUE][SPECIFICATION], l_data->cpu_model, l_data->cpu_ext_model, l_data->cpu_ext_family);
 	RETURN_OR_EXIT(2);
 }
@@ -1289,7 +1289,7 @@ static int cputab_package_fallback(Labels *data)
 		}
 	}
 
-	MSG_WARNING(_("Your CPU socket does not belong in database ==> %s, codename: %s"),
+	MSG_WARNING(_("Your CPU socket is not present in the database ==> %s, codename: %s"),
 		    data->tab_cpu[VALUE][SPECIFICATION], data->tab_cpu[VALUE][CODENAME]);
 	data->tab_cpu[VALUE][PACKAGE][0] = '\0';
 	return 2;

--- a/src/main.c
+++ b/src/main.c
@@ -348,7 +348,7 @@ static const struct
 	{ true,            "CPUX_BCLK",                N_("Enforce the bus clock")                                   },
 	{ true,            "CPUX_FORCE_FREQ_FALLBACK", N_("Ignore CPU frequency reported by libcpuid") },
 	{ HAS_LIBCPUID,    "CPUX_CPUID_RAW",           N_("Read CPUID raw data from a given file")                   },
-	{ HAS_LIBCPUID,    "CPUX_DEBUG_DATABASE",      N_("Only print a message if CPU does not belong in database") },
+	{ HAS_LIBCPUID,    "CPUX_DEBUG_DATABASE",      N_("Only print a message if CPU is not present in the database") },
 	{ true,            NULL,                       NULL                                                          }
 };
 


### PR DESCRIPTION
The one thing that does not belong here is "belong". :-)