### PR TITLE
Core: emit hex values with lowercase x and uppercase value

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -117,8 +117,8 @@ msgstr "تخطي البحث عن الأجهزة (تحتاج إلى صلاحيا�
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "بائع وحدة معالج البيانات غير معروف: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "بائع وحدة معالج البيانات غير معروف: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/ber.po
+++ b/po/ber.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
 msgstr ""
 
 #: core.c:837

--- a/po/cpu-x.pot
+++ b/po/cpu-x.pot
@@ -104,7 +104,7 @@ msgstr  ""
 
 #: core.c:821
 #, c-format
-msgid   "Your GPU vendor is unknown: %s (%#X)"
+msgid   "Your GPU vendor is unknown: %s (0x%X)"
 msgstr  ""
 
 #: core.c:837

--- a/po/cs_CZ.po
+++ b/po/cs_CZ.po
@@ -119,8 +119,8 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Neznámý výrobce grafického čipu: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Neznámý výrobce grafického čipu: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/da.po
+++ b/po/da.po
@@ -108,7 +108,7 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
 msgstr ""
 
 #: core.c:837

--- a/po/de.po
+++ b/po/de.po
@@ -115,8 +115,8 @@ msgstr "Suche nach Geräten überspringen (falsche Berechtigungen auf %s Gerät)
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Unbekannter GPU-Hersteller: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Unbekannter GPU-Hersteller: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/el.po
+++ b/po/el.po
@@ -106,7 +106,7 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
 msgstr ""
 
 #: core.c:837

--- a/po/es.po
+++ b/po/es.po
@@ -115,8 +115,8 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Su proveedor de GPU es desconocido: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Su proveedor de GPU es desconocido: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/fr.po
+++ b/po/fr.po
@@ -116,8 +116,8 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Le fabricant de votre carte-graphique est inconnu: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Le fabricant de votre carte-graphique est inconnu: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/hu.po
+++ b/po/hu.po
@@ -106,8 +106,8 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Ismeretlen GPU gyártó: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Ismeretlen GPU gyártó: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/id.po
+++ b/po/id.po
@@ -112,8 +112,8 @@ msgstr "Lewati pencarian perangkat (kesalahan izin pada perangkat %s)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Vendor GPU Anda tidak diketahui: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Vendor GPU Anda tidak diketahui: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/it.po
+++ b/po/it.po
@@ -112,8 +112,8 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Il produttore della tua GPU è sconosciuto: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Il produttore della tua GPU è sconosciuto: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/ja.po
+++ b/po/ja.po
@@ -108,7 +108,7 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
 msgstr ""
 
 #: core.c:837

--- a/po/ko.po
+++ b/po/ko.po
@@ -106,7 +106,7 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
 msgstr ""
 
 #: core.c:837

--- a/po/lv.po
+++ b/po/lv.po
@@ -111,8 +111,8 @@ msgstr "Ierīču meklēšana tiek izlaista (nepieciešamas root tiesības)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Jūsu GPU ražōtājs ir nezināms: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Jūsu GPU ražōtājs ir nezināms: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/mr.po
+++ b/po/mr.po
@@ -109,8 +109,8 @@ msgstr "डिव्हाइस शोध वगळा (%s डिव्हा�
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "आपला GPU विक्रेता अज्ञात आहे: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "आपला GPU विक्रेता अज्ञात आहे: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/ms.po
+++ b/po/ms.po
@@ -110,8 +110,8 @@ msgstr "Langkau gelintar peranti (perlu dalam root)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Vendor GPU anda tidak diketahui: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Vendor GPU anda tidak diketahui: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -111,8 +111,8 @@ msgstr "Hopp over søk etter enheter (feil tilganger på %s-enhet)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Din GPU-tilvirker er ukjent: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Din GPU-tilvirker er ukjent: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/pa.po
+++ b/po/pa.po
@@ -106,7 +106,7 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
 msgstr ""
 
 #: core.c:837

--- a/po/pl.po
+++ b/po/pl.po
@@ -116,8 +116,8 @@ msgstr "Pomiń wyszukiwanie urządzeń (brak uprawnień do urządzenia %s)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Dostawca procesora GPU jest nieznany: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Dostawca procesora GPU jest nieznany: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/pt.po
+++ b/po/pt.po
@@ -114,8 +114,8 @@ msgstr "Saltar a busca de aparelhos (permissões erradas no aparelho %s)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "O fabricante da GPU é desconhecido: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "O fabricante da GPU é desconhecido: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -114,8 +114,8 @@ msgstr "Pular pesquisa de dispositivos (permissões erradas no dispositivo %s)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Seu fabricante de GPU é desconhecido: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Seu fabricante de GPU é desconhecido: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/ru.po
+++ b/po/ru.po
@@ -119,8 +119,8 @@ msgstr "Пропустить поиск устройств (некорректн
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Неизвестный производитель ГП: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Неизвестный производитель ГП: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/tr.po
+++ b/po/tr.po
@@ -121,8 +121,8 @@ msgstr "Aygıt aramayı atla (%s aygıtında yanlış izinler)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "GPU satıcınız bilinmiyor: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "GPU satıcınız bilinmiyor: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/uk.po
+++ b/po/uk.po
@@ -116,8 +116,8 @@ msgstr "Пропустити пошук пристроїв (потрібно м�
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "Постачальник графічного процесора невідомий: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "Постачальник графічного процесора невідомий: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/zh.po
+++ b/po/zh.po
@@ -111,8 +111,8 @@ msgstr "跳过设备搜索 (%s设备上的权限错误)"
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "您的 GPU 供应商未知: %s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "您的 GPU 供应商未知: %s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -110,8 +110,8 @@ msgstr ""
 
 #: core.c:821
 #, c-format
-msgid "Your GPU vendor is unknown: %s (%#X)"
-msgstr "無法得知您的 GPU 供應商：%s (%#X)"
+msgid "Your GPU vendor is unknown: %s (0x%X)"
+msgstr "無法得知您的 GPU 供應商：%s (0x%X)"
 
 #: core.c:837
 msgid "failed to find chipset vendor and model"

--- a/src/core.c
+++ b/src/core.c
@@ -272,10 +272,10 @@ static int call_libcpuid_static(Labels *data)
 	/* Basically fill CPU tab */
 	casprintf(&data->tab_cpu[VALUE][CODENAME],      false, "%s",  datanr.cpu_codename);
 	casprintf(&data->tab_cpu[VALUE][SPECIFICATION], false, "%s",  datanr.brand_str);
-	casprintf(&data->tab_cpu[VALUE][FAMILY],        false, "%#X", datanr.family);
-	casprintf(&data->tab_cpu[VALUE][EXTFAMILY],     false, "%#X", datanr.ext_family);
-	casprintf(&data->tab_cpu[VALUE][MODEL],         false, "%#X", datanr.model);
-	casprintf(&data->tab_cpu[VALUE][EXTMODEL],      false, "%#X", datanr.ext_model);
+	casprintf(&data->tab_cpu[VALUE][FAMILY],        false, "0x%X", datanr.family);
+	casprintf(&data->tab_cpu[VALUE][EXTFAMILY],     false, "0x%X", datanr.ext_family);
+	casprintf(&data->tab_cpu[VALUE][MODEL],         false, "0x%X", datanr.model);
+	casprintf(&data->tab_cpu[VALUE][EXTMODEL],      false, "0x%X", datanr.ext_model);
 	casprintf(&data->tab_cpu[VALUE][STEPPING],      false, "%d",  datanr.stepping);
 	casprintf(&data->tab_cpu[VALUE][CORES],         true,  "%d",  datanr.num_cores);
 	casprintf(&data->tab_cpu[VALUE][THREADS],       true,  "%d",  datanr.num_logical_cpus);
@@ -817,7 +817,7 @@ static int find_devices(Labels *data)
 				case 0x8086: gpu_vendor = "Intel";  break;
 				case 0x10DE: gpu_vendor = "NVIDIA"; break;
 				default:     gpu_vendor = DEVICE_VENDOR_STR(dev);
-				             MSG_WARNING(_("Your GPU vendor is unknown: %s (%#X)"), gpu_vendor, dev->vendor_id);
+				             MSG_WARNING(_("Your GPU vendor is unknown: %s (0x%X)"), gpu_vendor, dev->vendor_id);
 			}
 
 			memset(gpu_driver, 0, MAXSTR);


### PR DESCRIPTION
Printing the 0x prefix uppercase is very uncommon and could lead one
to believe that the model number is a 4-character string "0X8E".
Change this to 0x8E.