### PR TITLE
Removed potentially dangerous compiler flags

### DIFF
--- a/src/dmidecode/CMakeLists.txt
+++ b/src/dmidecode/CMakeLists.txt
@@ -4,7 +4,7 @@ project(dmidecode
 )
 
 # Config (dmidecode)
-set(CMAKE_C_FLAGS       "${CMAKE_C_FLAGS} -Wno-format -Wno-format-security")
+set(CMAKE_C_FLAGS       "${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wno-shift-count-overflow")
 message(STATUS "Using built-in ${PROJECT_NAME}, version ${PROJECT_VERSION}")
 


### PR DESCRIPTION
Fixes the following issue:
```
cc1: error: -Wformat-security ignored without -Wformat [-Werror=format-security]
```
