### PR TITLE
Re: edit CMakeLists.txt for fix Segmentation fault

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,13 +74,12 @@ endif(WITH_LIBPCI)
 
 # Libglfw
 if(WITH_LIBGLFW)
-	pkg_check_modules(LIBOPENGL opengl)
+	pkg_check_modules(LIBOPENGL gl)
 	pkg_check_modules(LIBGLFW glfw3)
 	if(LIBOPENGL_FOUND AND LIBGLFW_FOUND)
 		include_directories(${LIBOPENGL_INCLUDE_DIRS} ${LIBGLFW_INCLUDE_DIRS})
 		link_directories(${LIBOPENGL_LIBRARY_DIRS} ${LIBGLFW_LIBRARY_DIRS})
 		add_definitions(${LIBOPENGL_CFLAGS_OTHER} ${LIBGLFW_CFLAGS_OTHER})
-		set(LIBGLFW_LIBRARIES "GL" ${LIBGLFW_LIBRARIES})
 	endif(LIBOPENGL_FOUND AND LIBGLFW_FOUND)
 endif(WITH_LIBGLFW)
 

--- a/src/core.c
+++ b/src/core.c
@@ -757,6 +757,9 @@ static int find_gpu_user_mode_driver(enum EnGpuDrv gpu_driver, char *user_mode_d
 	glfwMakeContextCurrent(win);
 	gl_ver = (const char*) glGetString(GL_VERSION);
 
+	if(gl_ver == NULL)
+		return 1;
+
 	switch(gpu_driver)
 	{
 		case GPUDRV_AMDGPU:


### PR DESCRIPTION
Related: #190

Sorry, If the linker has `-lOpenGL`, it seems to generate Segmentation fault.

Segmentation fault occurs when the strstr function receives NULL. 

OS: Debian GNU/Linux bullseye/sid
pkg-config: 0.29.2
CMake: cmake version 3.18.4

Before
\<build dir\>/src/CMakeFiles/cpu-x.dir/link.txt : 

`/usr/bin/cc  -Wno-deprecated-declarations -Wno-unused-result  -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -no-pie -rdynamic CMakeFiles/cpu-x.dir/main.c.o CMakeFiles/cpu-x.dir/util.c.o CMakeFiles/cpu-x.dir/core.c.o -o ../output/bin/cpu-x  -lm -lpthread ../output/lib/libgui_gtk.a -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0 ../output/lib/libtui_ncurses.a -lncursesw -ltinfo -lcpuid -lpci -lOpenGL -lGL -lglfw -lprocps ../output/lib/libdmidecode.a ../output/lib/libbandwidth.a 
`