### PR TITLE
WIP: Support for the hybrid processor

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -261,8 +261,9 @@ static int call_libcpuid_static(Labels *data)
 	const char *fmt_lines    = _("%s associative, %d-%s line size");
 	struct cpu_raw_data_t raw;
 	struct cpu_id_t datanr;
-
 	cpu_set_t *cpuset;
+	bool is_hybrid;
+
 	cpuset = CPU_ALLOC(0);
 	CPU_ZERO_S(sizeof(cpuset), cpuset);
 	if(cpuset == NULL)
@@ -293,6 +294,23 @@ static int call_libcpuid_static(Labels *data)
 	{
 		MSG_ERROR(_("failed to call libcpuid (%s)"), cpuid_error());
 		return 1;
+	}
+
+	/* Hybrid flag: EAX=0x7, ECX=0 => EDX: Bit15 */
+	is_hybrid = ((raw.basic_cpuid[0x7][3] >> 15) & 1) == 1;
+	if(is_hybrid)
+	{
+		/* Core Type: EAX=0x1A, ECX=0 => EAX: Bit31-24 */
+		uint32_t core_type = (raw.basic_cpuid[0x1A][0] >> 24);
+		switch(core_type)
+		{
+			case INTEL_CORE:
+				break;
+			case INTEL_ATOM:
+				break;
+			default:
+				break;
+		}
 	}
 
 	/* Some prerequisites */

--- a/src/core.c
+++ b/src/core.c
@@ -34,6 +34,7 @@
 #include <sys/utsname.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <sched.h>
 #include "core.h"
 #include "cpu-x.h"
 #include "ipc.h"
@@ -260,6 +261,22 @@ static int call_libcpuid_static(Labels *data)
 	const char *fmt_lines    = _("%s associative, %d-%s line size");
 	struct cpu_raw_data_t raw;
 	struct cpu_id_t datanr;
+
+	cpu_set_t *cpuset;
+	cpuset = CPU_ALLOC(0);
+	CPU_ZERO_S(sizeof(cpuset), cpuset);
+	if(cpuset == NULL)
+	{
+		MSG_ERROR(_("failed to call CPU_ZERO_S"));
+		return 1;
+	}
+	CPU_SET(0, cpuset);
+	err = sched_setaffinity(0, sizeof(cpuset), cpuset);
+	if(err)
+	{
+		MSG_ERROR(_("failed to call sched_setaffinity"));
+		return 1;
+	}
 
 	/* Call libcpuid */
 	MSG_VERBOSE("%s", _("Calling libcpuid for retrieving static data"));

--- a/src/cpu-x.h
+++ b/src/cpu-x.h
@@ -246,6 +246,11 @@ enum EnMultipliers
 	MULT_T
 };
 
+enum CoreType {
+	INTEL_ATOM = 0x20,
+	INTEL_CORE = 0x40,
+};
+
 typedef struct
 {
 	int8_t  cpu_vendor_id;
@@ -330,6 +335,12 @@ typedef struct
 	char     *prefix;
 	uint64_t divisor;
 } PrefixUnit;
+
+typedef struct
+{
+	uint32_t big_cpu_count, small_cpu_count;
+	uint32_t big_th_per_cpu, small_th_per_cpu;
+} HybridTopology;
 
 extern Options *opts;
 


### PR DESCRIPTION
Related: <https://github.com/X0rg/CPU-X/issues/205>

 * P-Core (INTEL_CORE, Big) / E-Core (INTEL_ATOM, Small) count
 * Thread per P/E-Core
 * CPU cache info of P/E-Core
     * Number of cache instances (4x E-Core shaed L2cache)

## Flow
 1. Set thread to CPU0 (sched_setaffinity)
 2. Check the hybrid frag [EAX=0x7, ECX=0 => EDX: Bit15]
 3. Check the cpu core type  [EAX=0x1A, ECX=0 => EAX: Bit31-24]
 3a. If P-Core, get the information of P-Core
 3a-1. Set thread to CPU{cpu_set} (cpu_set = TOTAL_THREAD-1)
 3a-2. if E-Core, check the number of thread shared L2cache (th_l2_shared) [EAX=0x4, ECX=0x2 => EAX: Bit25-14]
 3a-3. Set thread to CPU{cpu_set} (cpu_set = TOTAL_THREAD - th_l2_shared)
 3a-4: To 3. If E-Core, to 3a-2. if P-Core, to 4.
 3b-1: If E-Core, check the number of thread shared L2cache.
 3b-2: Set thread to CPU{cpu_set} (cpu_set = TOTAL_THREAD + th_l2_shared,
    if (TOTAL_THREAD <= cpu_set) cpu_set = TOTAL_THREAD )
 3b-3: To 3. if E-Core, to 3b-2. if P-Core, to 4.
 4. Output information of the hybrid processor, then done.
 
I don't have Intel Alder Lake, so I think it will take some time to implement. 
In supporting the hybrid processor, `libcpuid` lacks some features.
However, it is difficult to add supporting the hybrid processor to `libcpuid`, for me.

https://github.com/Umio-Yasuno/CPU-X/tree/wip-hybrid