### PR TITLE
TUI: Fix Graphics tab refresh

### DIFF
--- a/src/tui_ncurses.c
+++ b/src/tui_ncurses.c
@@ -437,24 +437,22 @@ static void nrefresh(NThrd *refr)
 			break;
 		case NO_GRAPHICS:
 			do_refresh(data);
-			line = LINE_3;
+			line = LINE_5;
 			for(i = 0; i < data->gpu_count * GPUFIELDS; i += GPUFIELDS)
 			{
-				mvwprintw2c(win, line, info.tm, "%18s: %s", data->tab_graphics[NAME][GPU1DIDRID      + i], data->tab_graphics[VALUE][GPU1DIDRID     + i]);
-				line++;
-				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1PCIE        + i], data->tab_graphics[VALUE][GPU1PCIE       + i]);
+				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1PCIE        + i], data->tab_graphics[VALUE][GPU1PCIE        + i]);
 				line++;
 				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1TEMPERATURE + i], data->tab_graphics[VALUE][GPU1TEMPERATURE + i]);
 				mvwprintw2c(win, line, info.tm, "%18s: %s", data->tab_graphics[NAME][GPU1USAGE       + i], data->tab_graphics[VALUE][GPU1USAGE       + i]);
 				line++;
-				mvwprintw2c(win, line, info.tm, "%18s: %s", data->tab_graphics[NAME][GPU1MEMUSED     + i], data->tab_graphics[VALUE][GPU1MEMUSED     + i]);
+				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1VOLTAGE     + i], data->tab_graphics[VALUE][GPU1VOLTAGE     + i]);
+				mvwprintw2c(win, line, info.tm, "%18s: %s", data->tab_graphics[NAME][GPU1POWERAVG    + i], data->tab_graphics[VALUE][GPU1POWERAVG    + i]);
 				line++;
-				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1CORECLOCK + i], data->tab_graphics[VALUE][GPU1CORECLOCK     + i]);
-				mvwprintw2c(win, line, info.tm, "%18s: %s", data->tab_graphics[NAME][GPU1MEMCLOCK  + i], data->tab_graphics[VALUE][GPU1MEMCLOCK      + i]);
+				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1CORECLOCK   + i], data->tab_graphics[VALUE][GPU1CORECLOCK   + i]);
+				mvwprintw2c(win, line, info.tm, "%18s: %s", data->tab_graphics[NAME][GPU1MEMCLOCK    + i], data->tab_graphics[VALUE][GPU1MEMCLOCK    + i]);
 				line++;
-				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1VOLTAGE   + i], data->tab_graphics[VALUE][GPU1VOLTAGE       + i]);
-				mvwprintw2c(win, line, info.tm, "%18s: %s", data->tab_graphics[NAME][GPU1POWERAVG  + i], data->tab_graphics[VALUE][GPU1POWERAVG      + i]);
-				line += LINE_3 - 1;
+				mvwprintw2c(win, line, info.tb, "%13s: %s", data->tab_graphics[NAME][GPU1MEMUSED     + i], data->tab_graphics[VALUE][GPU1MEMUSED     + i]);
+				line += LINE_5 - 1;
 			}
 			break;
 		case NO_BENCH:


### PR DESCRIPTION
Fix flickering when using terminal app with high refresh rate (like WezTerm, Alacritty).

 * DeviceID is not dynamically updated
 * Fix line number (I forgot about it during a previous PR.)
     * <https://github.com/X0rg/CPU-X/pull/194>
 * Fix Memory Used format

For now, this pull request does not conflict with <https://github.com/X0rg/CPU-X/pull/227>.  

before:
https://user-images.githubusercontent.com/53935716/184061486-89e1ee16-ac20-4443-8a56-49a1f6723c71.mp4

after:
https://user-images.githubusercontent.com/53935716/184061509-855fbcb0-1703-4cf7-a1f7-e27cfb95cb5a.mp4

