### PR TITLE
improved Vulkan RT detection and device matching

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -968,8 +968,12 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 {
 	int err = 0;
 #if HAS_LIBGLFW && HAS_Vulkan
-	uint32_t i, j, device_count = 0;
-	const char* const ext_names[] = { "VK_KHR_get_physical_device_properties2" };
+# define VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR 0x00000001
+	uint32_t i, device_count = 0;
+	const char* const ext_names[] = {
+		"VK_KHR_get_physical_device_properties2",
+		"VK_KHR_portability_enumeration",
+	};
 
 	if (glfwVulkanSupported() == GLFW_FALSE) {
 		MSG_WARNING("%s", _("Vulkan API is not available"));
@@ -979,6 +983,7 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 	VkInstance instance = {0};
 	VkInstanceCreateInfo createInfo = {
 		.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+		.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR,
 		.enabledExtensionCount = sizeof(ext_names) / sizeof(const char*),
 		.ppEnabledExtensionNames = ext_names,
 	};


### PR DESCRIPTION
 * e64d325733425b05426e0d8b159592d9e292d872
   * Checks the result of `vkCreateDevice` for Vulkan RT detection.
   * If the device does not support `VK_KHR_acceleration_structure`, `vkCreateDevice` returns `VK_ERROR_EXTENSION_NOT_PRESENT`.
 * edf40aac46444c0aaa5541dc6395e4a203c34f47
   * Use `VK_EXT_pci_bus_info` for device matching. This is more accurate than deviceID only.
   * `VK_EXT_pci_bus_info` is supported by most Vulkan drivers for Linux.
     *  [VK_EXT_pci_bus_info - Vulkan Hardware Database by Sascha Willems](https://vulkan.gpuinfo.org/listdevicescoverage.php?extension=VK_EXT_pci_bus_info)  
 * d741872799a099765050a89e511540ac3554e68b
   * Re-enable `VK_KHR_portability_enumeration` and `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR`.

## Ref:
 * [VkInstanceCreateFlagBits(3)](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkInstanceCreateFlagBits.html)
 * [vkCreateDevice(3)](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateDevice.html)
 * [VK_EXT_pci_bus_info(3)](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pci_bus_info.html)
   * [VkPhysicalDevicePCIBusInfoPropertiesEXT(3)](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDevicePCIBusInfoPropertiesEXT.html)
 * [VkPhysicalDeviceProperties2(3)](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceProperties2.html)
 * [vkGetPhysicalDeviceProperties2(3)](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceProperties2.html)