### PR TITLE
cleanup the Vulkan code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,6 @@ option(WITH_BANDWIDTH     "Built-in Bandwidth"                                  
 option(FORCE_LIBSTATGRAB  "Force use of Libstatgrab instead of Libprocps (GNU/Linux system)"  OFF)
 option(APPIMAGE           "Enable workarounds for AppImage"                                   OFF)
 
-if(NOT WITH_LIBGLFW)
-	set(WITH_VULKAN OFF)
-endif(NOT WITH_LIBGLFW)
-
 # Colours
 string(ASCII 27 Esc)
 set(ColourReset "${Esc}[m")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,15 +71,17 @@ if(WITH_LIBGLFW)
 		add_definitions(${LIBGL_CFLAGS_OTHER} ${LIBGLFW_CFLAGS_OTHER})
 	endif(LIBGL_FOUND AND LIBGLFW_FOUND)
 
-	if(WITH_VULKAN)
-		pkg_check_modules(VULKAN vulkan)
-		if(VULKAN_FOUND AND LIBGLFW_FOUND)
-			include_directories(${VULKAN_INCLUDE_DIRS})
-			link_directories(${VULKAN_LIBRARY_DIRS})
-			add_definitions(${VULKAN_CFLAGS_OTHER})
-		endif(VULKAN_FOUND AND LIBGLFW_FOUND)
-	endif(WITH_VULKAN)
 endif(WITH_LIBGLFW)
+
+# Vulkan
+if(WITH_VULKAN)
+	pkg_check_modules(VULKAN vulkan)
+	if(VULKAN_FOUND)
+		include_directories(${VULKAN_INCLUDE_DIRS})
+		link_directories(${VULKAN_LIBRARY_DIRS})
+		add_definitions(${VULKAN_CFLAGS_OTHER})
+	endif(VULKAN_FOUND)
+endif(WITH_VULKAN)
 
 # OpenCL
 if(WITH_OPENCL)

--- a/src/core.c
+++ b/src/core.c
@@ -1140,6 +1140,7 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 		}
 	}
 # endif /* VK_EXT_PCI_BUS_INFO_EXTENSION_NAME */
+	vkDestroyInstance(instance, NULL);
 	free(devices);
 #else
 	UNUSED(dev);

--- a/src/core.c
+++ b/src/core.c
@@ -1154,7 +1154,6 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 
 	return err;
 }
-#undef VULKAN_MAX_EXTENSION_NAMES
 
 #define CLINFO(dev_id, PARAM, prop) \
 	clGetDeviceInfo(dev_id, PARAM, sizeof(prop), &prop, NULL)

--- a/src/core.c
+++ b/src/core.c
@@ -73,13 +73,12 @@
 #endif
 
 #if HAS_LIBGLFW
-# if HAS_Vulkan
-#   define VK_VERSION_1_1
-#	define GLFW_INCLUDE_VULKAN
-#	include <vulkan/vulkan.h>
-# endif
 # include <GL/gl.h>
 # include <GLFW/glfw3.h>
+#endif
+
+#if HAS_Vulkan
+# include <vulkan/vulkan.h>
 #endif
 
 #if HAS_OpenCL
@@ -984,7 +983,7 @@ static inline const char* string_VkResult(VkResult input_value)
 static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, bool *vulkan_rt)
 {
 	int err = 0;
-#if HAS_LIBGLFW && HAS_Vulkan
+#if HAS_Vulkan
 	uint32_t i, device_count = 0;
 	bool use_device_id = false;
 	VkInstance instance = {0};
@@ -997,11 +996,6 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 	};
 
 	MSG_VERBOSE("%s", _("Finding Vulkan API version"));
-	if(glfwVulkanSupported() == GLFW_FALSE)
-	{
-		MSG_WARNING("%s", _("Vulkan API is not available"));
-		return err;
-	}
 
 	const VkInstanceCreateInfo createInfo =
 	{
@@ -1151,7 +1145,7 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 	UNUSED(dev);
 	UNUSED(vulkan_version);
 	UNUSED(vulkan_rt);
-#endif /* HAS_LIBGLFW && HAS_Vulkan */
+#endif /* HAS_Vulkan */
 
 	return err;
 }

--- a/src/core.c
+++ b/src/core.c
@@ -1016,7 +1016,10 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 
 		if(err == VK_ERROR_EXTENSION_NOT_PRESENT)
 		{
-			MSG_ERROR("%s", _("VK_KHR_get_physical_device_properties2 and VK_KHR_portability_enumeration are not supported"));
+			MSG_ERROR(_("%s is not supported"), VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+# ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+			MSG_ERROR(_("%s is not supported"), VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+# endif /* VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME */
 		}
 
 		return err;
@@ -1108,7 +1111,7 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 
 			if(err == VK_ERROR_EXTENSION_NOT_PRESENT)
 			{
-				MSG_WARNING(_("VK_EXT_pci_bus_info is not supported for device %u, use only deviceID for matching"), i);
+				MSG_WARNING(_("%s is not supported for device %u, use only deviceID for matching"), VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, i);
 				use_device_id = true;
 			}
 		}

--- a/src/core.c
+++ b/src/core.c
@@ -1049,7 +1049,7 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 		return err;
 	}
 
-	VkDeviceQueueCreateInfo queueCreateInfo =
+	const VkDeviceQueueCreateInfo queueCreateInfo =
 	{
 		.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
 		.pNext = NULL,
@@ -1124,8 +1124,8 @@ static int get_vulkan_api_version(struct pci_dev *dev, char *vulkan_version, boo
 		    dev->bus                 == bus_info.pciBus       &&
 		    dev->dev                 == bus_info.pciDevice    &&
 		    dev->func                == bus_info.pciFunction) ||
-		    (use_device_id &&
-		     (uint32_t)dev->device_id == prop2.properties.deviceID))
+		   (use_device_id &&
+		    (uint32_t)dev->device_id == prop2.properties.deviceID))
 		{
 # ifdef VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME
 			if (vkCreateDevice(devices[i], &check_rt, NULL, &vk_dev) == VK_SUCCESS)


### PR DESCRIPTION
This PR removes the dependence LIBGLFW from Vulkan, cleanups the Vulkan code, add failback for device matching.